### PR TITLE
simplify analysis_options.yaml usage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,5 @@
 #   Name/Organization <email address>
 
 Google Inc.
+
+Alexandre Ardhuin <alexandre.ardhuin@gmail.com>

--- a/README.md
+++ b/README.md
@@ -30,18 +30,33 @@ Here is how static analysis is used internally at Google:
  - Lints are considered and enabled on a case by case basis. When enabling a
    lint we first clean up all pre-existing violations. After it's enabled, any
    attempt to check in a further violation will be blocked.
-   
+
 ## Enabled Lints
 
 The currently enabled lints can be found in the sample
-[analysis_options.yaml](https://github.com/dart-lang/pedantic/blob/master/analysis_options.yaml).
+[analysis_options.yaml](https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.yaml).
+
+### Usage
+
+To use those lints you can add a dev dependency in your `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  pedantic: '1.1.0'
+```
+
+and add an include in your `analysis_options.yaml`:
+
+```yaml
+include: package:pedantic/analysis_options.yaml
+```
 
 ## Unused Lints
 
 The following lints have been considered and will _not_ be enforced:
 
 `always_put_control_body_on_new_line`
-violates Effective Dart "DO format your code using dartfmt". See note about 
+violates Effective Dart "DO format your code using dartfmt". See note about
 Flutter SDK style below.
 
 `always_specify_types`

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Here is how static analysis is used internally at Google:
 The currently enabled lints can be found in the sample
 [analysis_options.yaml](https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.yaml).
 
-### Usage
-
 To use those lints you can add a dev dependency in your `pubspec.yaml`:
 
 ```yaml

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,19 +5,4 @@
 # Google internally enforced rules. See README.md for more information,
 # including a list of lints that are intentionally _not_ enforced.
 
-linter:
-  rules:
-    - avoid_empty_else
-    - avoid_relative_lib_imports
-    - avoid_return_types_on_setters
-    - avoid_types_as_parameter_names
-    - control_flow_in_finally
-    - no_duplicate_case_values
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_is_not_empty
-    - recursive_getters
-    - throw_in_finally
-    - unrelated_type_equality_checks
-    - use_rethrow_when_possible
-    - valid_regexps
+include: lib/analysis_options.yaml

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+#
+# Google internally enforced rules. See README.md for more information,
+# including a list of lints that are intentionally _not_ enforced.
+
+linter:
+  rules:
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_types_as_parameter_names
+    - control_flow_in_finally
+    - no_duplicate_case_values
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_is_not_empty
+    - recursive_getters
+    - throw_in_finally
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    - valid_regexps


### PR DESCRIPTION
This PR allows to avoid copy-pasting lint lists and simplify its handling and versioning.