### PR TITLE
Bump new rules enforced in Google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.5.0
+
+- Enforce three new lint rules:
+  - `[avoid_shadowing_type_parameters]`,
+  - `[empty_constructor_bodies]`,
+  - `[slash_for_doc_comments]` - Violations can be cleaned up with
+    [the formatter]'s `--fix-doc-comments` flag.
+
+[avoid_shadowing_type_parameters]: http://dart-lang.github.io/linter/lints/avoid_shadowing_type_parameters.html
+[empty_constructor_bodies]: http://dart-lang.github.io/linter/lints/empty_constructor_bodies.html
+[slash_for_doc_comments]: http://dart-lang.github.io/linter/lints/slash_for_doc_comments.html
+[the formatter]: https://github.com/dart-lang/dart_style#style-fixes
+
 ## 1.4.0
 
 - Enforce `avoid_init_to_null` and `null_closures`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## 1.5.0
 
 - Enforce three new lint rules:
-  - `[avoid_shadowing_type_parameters]`,
-  - `[empty_constructor_bodies]`,
-  - `[slash_for_doc_comments]` - Violations can be cleaned up with
+  - [`avoid_shadowing_type_parameters`],
+  - [`empty_constructor_bodies`],
+  - [`slash_for_doc_comments`] - Violations can be cleaned up with
     [the formatter]'s `--fix-doc-comments` flag.
 
-[avoid_shadowing_type_parameters]: http://dart-lang.github.io/linter/lints/avoid_shadowing_type_parameters.html
-[empty_constructor_bodies]: http://dart-lang.github.io/linter/lints/empty_constructor_bodies.html
-[slash_for_doc_comments]: http://dart-lang.github.io/linter/lints/slash_for_doc_comments.html
+[`avoid_shadowing_type_parameters`]: http://dart-lang.github.io/linter/lints/avoid_shadowing_type_parameters.html
+[`empty_constructor_bodies`]: http://dart-lang.github.io/linter/lints/empty_constructor_bodies.html
+[`slash_for_doc_comments`]: http://dart-lang.github.io/linter/lints/slash_for_doc_comments.html
 [the formatter]: https://github.com/dart-lang/dart_style#style-fixes
 
 ## 1.4.0

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -11,7 +11,9 @@ linter:
     - avoid_init_to_null
     - avoid_relative_lib_imports
     - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
     - avoid_types_as_parameter_names
+    - empty_constructor_bodies
     - no_duplicate_case_values
     - null_closures
     - prefer_contains
@@ -19,7 +21,8 @@ linter:
     - prefer_is_empty
     - prefer_is_not_empty
     - recursive_getters
+    - slash_for_doc_comments
+    - unawaited_futures
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
-    - unawaited_futures
     - valid_regexps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: pedantic
-version: 1.4.0
+version: 1.5.0
 description: How to get the most value from Dart static analysis.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/pedantic
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.1-dev.0.0 <3.0.0'


### PR DESCRIPTION
This adds 3 new rules. Including one that was introduced into the Dart SDK in 2.1.1-dev.0.0, so I've bumped the minimum SDK version.

Since the analyzer won't break if there are unknown linter rules present in analysis_options, we don't have to bump the minimum SDK version. LMK.