### PR TITLE
 Enforce three new lint rules and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.8.0
+- Enforce three new lint rules:
+
+  - [`prefer_iterable_whereType`]
+  - [`unnecessary_const`]
+  - [`unnecessary_new`]
+
+[`prefer_iterable_whereType`]: https://dart-lang.github.io/linter/lints/prefer_iterable_whereType.html
+[`unnecessary_const`]: https://dart-lang.github.io/linter/lints/unnecessary_const.html
+[`unnecessary_new`]: https://dart-lang.github.io/linter/lints/unnecessary_new.html
+
 ## 1.7.0
 
 - Add versioned `analysis_options.yaml` files to the package so it's possible

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Here is how static analysis is used internally at Google:
  - Lints are considered and enabled on a case by case basis. When enabling a
    lint we first clean up all pre-existing violations. After it's enabled, any
    attempt to check in a further violation will be blocked.
-   
+
 ## Enabled Lints
 
 The currently enabled lints can be found in
-[analysis_options.1.7.0.yaml](https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.1.7.0.yaml).
+[analysis_options.1.8.0.yaml](https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.1.8.0.yaml).
 
 ## Using the Lints
 
@@ -48,11 +48,11 @@ To use the lints add a dependency in your `pubspec.yaml`:
 ```yaml
 # If you use `package:pedantic/pedantic.dart`, add a normal dependency.
 dependencies:
-  pedantic: ^1.7.0
+  pedantic: ^1.8.0
 
 # Or, if you just want `analysis_options.yaml`, it can be a dev dependency.
 dev_dependencies:
-  pedantic: ^1.7.0
+  pedantic: ^1.8.0
 ```
 
 then, add an include in your `analysis_options.yaml`. If you want to always
@@ -69,7 +69,7 @@ fail whenever a new version of `package:pedantic` is released. To avoid this,
 specify a specific version of `analysis_options.yaml` instead:
 
 ```yaml
-include: package:pedantic/analysis_options.1.7.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
 ```
 
 ## Unused Lints

--- a/lib/analysis_options.1.8.0.yaml
+++ b/lib/analysis_options.1.8.0.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+#
+# Google internally enforced rules. See README.md for more information,
+# including a list of lints that are intentionally _not_ enforced.
+
+linter:
+  rules:
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - empty_constructor_bodies
+    - library_names
+    - library_prefixes
+    - no_duplicate_case_values
+    - null_closures
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_const
+    - unnecessary_new
+    - unnecessary_null_in_if_null_operators
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    - valid_regexps

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -10,4 +10,4 @@
 # whenever a new version of `package:pedantic` is released. To avoid this,
 # specify a specific version of `analysis_options.yaml` instead.
 
-include: package:pedantic/analysis_options.1.7.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pedantic
-version: 1.7.0
+version: 1.8.0
 description: How to get the most value from Dart static analysis.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/pedantic


### PR DESCRIPTION
 Enforce three new lint rules:

  - [`prefer_iterable_whereType`]
  - [`unnecessary_const`]
  - [`unnecessary_new`]

[`prefer_iterable_whereType`]: https://dart-lang.github.io/linter/lints/prefer_iterable_whereType.html
[`unnecessary_const`]: https://dart-lang.github.io/linter/lints/unnecessary_const.html
[`unnecessary_new`]: https://dart-lang.github.io/linter/lints/unnecessary_new.html

Fixes: #18