### PR TITLE
update version to `1.9.0-nnbd` and update the max sdk constraint to not allow stable sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.0-dev
+## 1.9.0-nnbd
 
 - Migrate to null safety.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: pedantic
-version: 1.10.0-dev
+version: 1.9.0-nnbd
 description: >-
   The Dart analyzer settings and best practices used internally at Google.
 homepage: https://github.com/dart-lang/pedantic
 
 environment:
-  sdk: '>=2.8.0-dev <3.0.0'
+  sdk: '>=2.8.0-dev <2.8.0'


### PR DESCRIPTION
See comments here for context https://github.com/dart-lang/pedantic/pull/50.